### PR TITLE
Add DASL_Uninstall notebook

### DIFF
--- a/DASL_Uninstall.ipynb
+++ b/DASL_Uninstall.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "8c02eeef-3d9c-4922-95e1-17eadbf97468",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%pip install databricks-sdk==0.57.0\n",
+    "dbutils.library.restartPython()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d5eec479-1c70-4b47-aa11-ee2466155cfb",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from databricks.sdk import WorkspaceClient\n",
+    "from databricks.sdk.errors.platform import NotFound\n",
+    "\n",
+    "# Name of the service principal created on install\n",
+    "# If you modified this field on install, change this to reflect the name\n",
+    "# you previously used.\n",
+    "# Alternatively, you may specify the exact ID of the service principal\n",
+    "# This can help disambiguate if there are multiple SPs with the same name\n",
+    "service_principal_name = \"patyang-test-privatelink-sp\"\n",
+    "service_principal_id = None\n",
+    "\n",
+    "# Name of the catalog created on install\n",
+    "# Setting this to `None` will prevent the catalog from being deleted in\n",
+    "# the case you prefer keeping the data intact after uninstallation\n",
+    "catalog_name = \"sec_lakehouse\"\n",
+    "\n",
+    "dbc = WorkspaceClient()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "b552dcfb-674d-4898-a607-7ca73cf4c391",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Delete the previously created service principal\n",
+    "# We do this first to prevent the ASL control plane from continuing to make\n",
+    "# changes in the mean time while the rest of the uninstall occurs\n",
+    "if service_principal_id is None:\n",
+    "  sps = list(dbc.service_principals.list(\n",
+    "    filter=f\"displayName eq '{service_principal_name}'\"\n",
+    "  ))\n",
+    "  if len(sps) == 1:\n",
+    "    try:\n",
+    "      sp = sps[0]\n",
+    "      dbc.service_principals.delete(sp.id)\n",
+    "      print(f\"Deleted service principal {sp.id} (name:{service_principal_name})\")\n",
+    "    except NotFound:\n",
+    "      print(f\"Skipping service principal deletion (name:{service_principal_name}) as it does not exist\")\n",
+    "  elif len(sps) > 1:\n",
+    "    raise Exception(f\"Multiple service principals named {service_principal_name} found, please specify `service_principal_id` to disambiguate\")\n",
+    "  else:\n",
+    "    print(f\"Skipping service principal deletion as could not find {service_principal_name}\")\n",
+    "\n",
+    "else:\n",
+    "  try:\n",
+    "    dbc.service_principals.delete(service_principal_id)\n",
+    "    print(f\"Deleted service principal {sp.id}\")\n",
+    "  except NotFound:\n",
+    "    print(f\"Skipping service principal deletion (id:{service_principal_id}) as it does not exist\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ceb00467-2381-47de-af46-91ad73f030b8",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if catalog_name is not None:\n",
+    "  # Force delete the catalog which includes all underlying schemas\n",
+    "  try:\n",
+    "    dbc.catalogs.delete(catalog_name, force=True)\n",
+    "  except NotFound:\n",
+    "    print(f\"Skipping catalog deletion ({catalog_name}) as it does not exist\")\n",
+    "else:\n",
+    "  print(\"Skipping catalog deletion as catalog_name is None\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "5ff063d9-fc26-4e9c-9878-c6360c765fdf",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Check if the workspace has IP Access Lists in use and remove the DASL control plane allow list, if it exists\n",
+    "try:\n",
+    "    conf_value = dbc.workspace_conf.get_status(keys=[\"enableIpAccessLists\"]).get(\"enableIpAccessLists\", \"false\")\n",
+    "    ip_access_list_enabled = (False if conf_value is None or conf_value.lower() != \"true\" else True)\n",
+    "    if ip_access_list_enabled:\n",
+    "      print (\"Workspace appears to use IP allow lists. Removing any previously created DASL IP Access List rules\")\n",
+    "      for l in dbc.ip_access_lists.list():\n",
+    "        if l.enabled == True and l.label == \"DASL\" and l.list_type == settings.ListType.ALLOW:\n",
+    "          dbc.ip_access_lists.delete(l.list_id)\n",
+    "          print (f\"Deleted IP allow list entry {l.list_id} (label:{l.label})\")\n",
+    "    else:\n",
+    "        print (\"Workspace does not appear to use IP allow lists\")\n",
+    "except NotFound as e:\n",
+    "    print(\"This workspace does not have IP access lists, nothing to be done\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "4ecb2da2-a2f5-44d8-b61f-163534e70aa1",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The DASL uninstallation from your workspace is now complete. \n",
+    "# Please contact Antimatter support to complete offboarding.\n",
+    "# Note that the service principals created during installation have been removed from the workspace\n",
+    "# but not fully deleted. You will need to manually delete them from the account console ('User Management' -> 'Service Principals')"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": {
+    "hardware": {
+     "accelerator": null,
+     "gpuPoolId": null,
+     "memory": null
+    }
+   },
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": -1,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 2
+   },
+   "notebookName": "DASL_Uninstall",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Databricks / Antimatter Security Lakehouse
 
-This repository contains artifacts that are used as part of the installation process of 
-the Databricks / Antimatter Security Lakehouse (DASL). Please see 
-[the docs](https://docs.sl.antimatter.io/summary) for more information.
+This repository contains artifacts that are used as part of the installation and 
+uninstallation processes of the Databricks / Antimatter Security Lakehouse (DASL). 
+Please see [the docs](https://docs.sl.antimatter.io/summary) for more information.


### PR DESCRIPTION
Likely easier to view the notebook contents by pressing "View File", like [this](https://github.com/antimatterhq/dasl-install/blob/8128e2e07285b46957109f64e80fc94b5bcb419a/DASL_Uninstall.ipynb).

I left the ability to remove the catalog name in case users want to keep the ingested data after uninstallation

Open question:
- Do we want to delete the `dasl-background-tasks` job and notebook?